### PR TITLE
Fix: Initialize rust cli project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cli-project"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,23 @@
-hello
+# CLI Project
+
+A simple Rust CLI application with three commands: foo, bar, and baz.
+
+## Usage
+
+```bash
+# Run the foo command
+cargo run -- foo
+
+# Run the bar command
+cargo run -- bar
+
+# Run the baz command
+cargo run -- baz
+```
+
+## Commands
+
+- **foo**: Prints "foo command was run"
+- **bar**: Prints "bar command was run"
+- **baz**: Prints "baz command was run"
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "cli-project")]
+#[command(about = "A simple CLI with foo, bar, and baz commands")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run the foo command
+    Foo,
+    /// Run the bar command
+    Bar,
+    /// Run the baz command
+    Baz,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Foo => {
+            println!("foo command was run");
+        }
+        Commands::Bar => {
+            println!("bar command was run");
+        }
+        Commands::Baz => {
+            println!("baz command was run");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the changes described in #2.

## Issue Description

Initialize a basic rust cli project with 3 commands:
- foo
- bar
- baz

Each command should simply print a message inidicating which command was run

## Comments

**@itsfrank**: 󰚩 **Auto-patcher** is starting work on this issue.

I will:
1. Clone the repository
2. Create branch `agent/issue-2`
3. Implement the necessary changes
4. Create a pull request

This may take a few m...

**@itsfrank**: 󰅖 **Auto-patcher** encountered an error while processing this issue.

Error: Git Repository is empty. - https://docs.github.com/rest/git/refs#get-a-reference

The `agent-ready` label has been removed...

**@itsfrank**: added a readme, that should fix the issue

**@itsfrank**: 󰚩 **Auto-patcher** is starting work on this issue.

I will:
1. Clone the repository
2. Create branch `agent/issue-2`
3. Implement the necessary changes
4. Create a pull request

This may take a few m...

**@itsfrank**: 󰚩 **Auto-patcher** is starting work on this issue.

I will:
1. Clone the repository
2. Create branch `agent/issue-2`
3. Implement the necessary changes
4. Create a pull request

This may take a few m...

---

Closes #2