### PR TITLE
Fix: Add version info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-project"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,9 @@ A simple Rust CLI application with commands: foo, bar, baz, and animal.
 ## Usage
 
 ```bash
+# Show version
+cargo run -- --version
+
 # Run the foo command
 cargo run -- foo
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(name = "cli-project")]
+#[command(version)]
 #[command(about = "A simple CLI with foo, bar, baz, and animal commands")]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

This PR implements the changes described in #8.

## Issue Description

we should be able to call the tool with `--version` to get the version for the tool.

Let's start it at 0.0.1

---

Closes #8