### PR TITLE
Fix: Add a tutorial command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # CLI Project
 
-A simple Rust CLI application with commands: foo, bar, baz, and animal.
+A simple Rust CLI application with commands: foo, bar, baz, animal, and tutorial.
 
 ## Usage
 
@@ -19,6 +19,9 @@ cargo run -- baz
 
 # Run the animal command
 cargo run -- animal <animal-type>
+
+# Run the tutorial command
+cargo run -- tutorial
 ```
 
 ## Commands
@@ -30,4 +33,5 @@ cargo run -- animal <animal-type>
   - **cat**: Prints a cute cat
   - **bird**: Prints a cute bird
   - **snake**: Prints a cute snake
+- **tutorial**: Interactive tutorial that teaches you about all the other commands
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use std::io::{self, Write};
 
 #[derive(Parser)]
 #[command(name = "cli-project")]
@@ -23,6 +24,8 @@ enum Commands {
         #[arg(value_enum)]
         animal: AnimalType,
     },
+    /// Interactive tutorial for learning about all commands
+    Tutorial,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -34,6 +37,79 @@ enum AnimalType {
     /// A cute snake
     #[clap(alias = "snek")]
     Snake,
+}
+
+fn wait_for_enter() {
+    print!("Press Enter to continue...");
+    io::stdout().flush().unwrap();
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+}
+
+fn run_tutorial() {
+    println!("Welcome to the CLI Project Tutorial!");
+    println!("=====================================\n");
+
+    println!("This tutorial will teach you about all the available commands.");
+    println!("Let's get started!\n");
+    wait_for_enter();
+
+    println!("\n--- Command 1: foo ---");
+    println!("The 'foo' command is the simplest command.");
+    println!("It just prints 'foo command was run' to the console.\n");
+    println!("Example:");
+    println!("  $ cli-project foo");
+    println!("  foo command was run\n");
+    wait_for_enter();
+
+    println!("\n--- Command 2: bar ---");
+    println!("The 'bar' command is similar to foo.");
+    println!("It prints 'bar command was run' to the console.\n");
+    println!("Example:");
+    println!("  $ cli-project bar");
+    println!("  bar command was run\n");
+    wait_for_enter();
+
+    println!("\n--- Command 3: baz ---");
+    println!("The 'baz' command is the third simple command.");
+    println!("It prints 'baz command was run' to the console.\n");
+    println!("Example:");
+    println!("  $ cli-project baz");
+    println!("  baz command was run\n");
+    wait_for_enter();
+
+    println!("\n--- Command 4: animal ---");
+    println!("The 'animal' command is more interesting!");
+    println!("It prints ASCII art of a cute animal.");
+    println!("You can choose from: cat, bird, or snake.\n");
+    println!("Examples:");
+    println!("  $ cli-project animal cat");
+    println!("   /\\_/\\");
+    println!("  ( o.o )");
+    println!("   > ^ <\n");
+    println!("  $ cli-project animal snake");
+    println!("       ____");
+    println!("      / o o\\");
+    println!("     |  >   |");
+    println!("      \\____/");
+    println!("         |");
+    println!("       __|");
+    println!("      | ...\n");
+    wait_for_enter();
+
+    println!("\n--- Command 5: tutorial ---");
+    println!("The 'tutorial' command (which you're using right now!)");
+    println!("is an interactive guide that teaches you about all the other commands.\n");
+    println!("Example:");
+    println!("  $ cli-project tutorial\n");
+    wait_for_enter();
+
+    println!("\n=====================================");
+    println!("Tutorial complete! You now know about all the commands:");
+    println!("  - foo, bar, baz: Simple commands that print messages");
+    println!("  - animal: Prints cute ASCII art animals");
+    println!("  - tutorial: This interactive guide");
+    println!("\nHappy coding!");
 }
 
 fn main() {
@@ -85,5 +161,8 @@ fn main() {
                 println!(" /");
             }
         },
+        Commands::Tutorial => {
+            run_tutorial();
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the changes described in #10.

## Issue Description

The tutorial command should teach the user about the other commands of the too interactively 

It should teach about one command, with for user input (e.g. hit enter) then the next until it's gone through all of them

---

Closes #10